### PR TITLE
Add Pop2 function

### DIFF
--- a/b16set/b16set.go
+++ b/b16set/b16set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...[16]byte) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() [16]byte {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() [16]byte {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() ([16]byte, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/b16set/b16set.go
+++ b/b16set/b16set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() [16]byte {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() ([16]byte, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...[16]byte) bool {

--- a/b16set/b16set_test.go
+++ b/b16set/b16set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 [16]byte
+	e := createRandomObject(e1)
+	if v, ok := e.([16]byte); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.([16]byte); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 [16]byte
 	e := createRandomObject(e1)

--- a/b32set/b32set.go
+++ b/b32set/b32set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...[32]byte) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() [32]byte {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() [32]byte {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() ([32]byte, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/b32set/b32set.go
+++ b/b32set/b32set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() [32]byte {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() ([32]byte, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...[32]byte) bool {

--- a/b32set/b32set_test.go
+++ b/b32set/b32set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 [32]byte
+	e := createRandomObject(e1)
+	if v, ok := e.([32]byte); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.([32]byte); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 [32]byte
 	e := createRandomObject(e1)

--- a/b64set/b64set.go
+++ b/b64set/b64set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...[64]byte) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() [64]byte {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() [64]byte {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() ([64]byte, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/b64set/b64set.go
+++ b/b64set/b64set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() [64]byte {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() ([64]byte, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...[64]byte) bool {

--- a/b64set/b64set_test.go
+++ b/b64set/b64set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 [64]byte
+	e := createRandomObject(e1)
+	if v, ok := e.([64]byte); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.([64]byte); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 [64]byte
 	e := createRandomObject(e1)

--- a/b8set/b8set.go
+++ b/b8set/b8set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...[8]byte) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() [8]byte {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() [8]byte {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() ([8]byte, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/b8set/b8set.go
+++ b/b8set/b8set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() [8]byte {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() ([8]byte, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...[8]byte) bool {

--- a/b8set/b8set_test.go
+++ b/b8set/b8set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 [8]byte
+	e := createRandomObject(e1)
+	if v, ok := e.([8]byte); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.([8]byte); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 [8]byte
 	e := createRandomObject(e1)

--- a/f32set/f32set.go
+++ b/f32set/f32set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() float32 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (float32, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...float32) bool {

--- a/f32set/f32set.go
+++ b/f32set/f32set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...float32) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() float32 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() float32 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (float32, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/f32set/f32set_test.go
+++ b/f32set/f32set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 float32
+	e := createRandomObject(e1)
+	if v, ok := e.(float32); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(float32); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 float32
 	e := createRandomObject(e1)

--- a/f64set/f64set.go
+++ b/f64set/f64set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...float64) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() float64 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() float64 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (float64, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/f64set/f64set.go
+++ b/f64set/f64set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() float64 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (float64, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...float64) bool {

--- a/f64set/f64set_test.go
+++ b/f64set/f64set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 float64
+	e := createRandomObject(e1)
+	if v, ok := e.(float64); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(float64); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 float64
 	e := createRandomObject(e1)

--- a/i16set/i16set.go
+++ b/i16set/i16set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...int16) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() int16 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() int16 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (int16, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/i16set/i16set.go
+++ b/i16set/i16set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() int16 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (int16, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...int16) bool {

--- a/i16set/i16set_test.go
+++ b/i16set/i16set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 int16
+	e := createRandomObject(e1)
+	if v, ok := e.(int16); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(int16); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 int16
 	e := createRandomObject(e1)

--- a/i32set/i32set.go
+++ b/i32set/i32set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() int32 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (int32, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...int32) bool {

--- a/i32set/i32set.go
+++ b/i32set/i32set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...int32) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() int32 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() int32 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (int32, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/i32set/i32set_test.go
+++ b/i32set/i32set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 int32
+	e := createRandomObject(e1)
+	if v, ok := e.(int32); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(int32); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 int32
 	e := createRandomObject(e1)

--- a/i64set/i64set.go
+++ b/i64set/i64set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...int64) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() int64 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() int64 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (int64, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/i64set/i64set.go
+++ b/i64set/i64set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() int64 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (int64, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...int64) bool {

--- a/i64set/i64set_test.go
+++ b/i64set/i64set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 int64
+	e := createRandomObject(e1)
+	if v, ok := e.(int64); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(int64); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 int64
 	e := createRandomObject(e1)

--- a/i8set/i8set.go
+++ b/i8set/i8set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() int8 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (int8, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...int8) bool {

--- a/i8set/i8set.go
+++ b/i8set/i8set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...int8) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() int8 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() int8 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (int8, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/i8set/i8set_test.go
+++ b/i8set/i8set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 int8
+	e := createRandomObject(e1)
+	if v, ok := e.(int8); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(int8); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 int8
 	e := createRandomObject(e1)

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() T {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (T, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...T) bool {

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...T) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() T {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() T {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (T, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 T
+	e := createRandomObject(e1)
+	if v, ok := e.(T); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(T); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 T
 	e := createRandomObject(e1)

--- a/iset/iset.go
+++ b/iset/iset.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...int) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() int {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() int {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (int, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/iset/iset.go
+++ b/iset/iset.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() int {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (int, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...int) bool {

--- a/iset/iset_test.go
+++ b/iset/iset_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 int
+	e := createRandomObject(e1)
+	if v, ok := e.(int); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(int); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 int
 	e := createRandomObject(e1)

--- a/strset/strset.go
+++ b/strset/strset.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() string {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (string, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...string) bool {

--- a/strset/strset.go
+++ b/strset/strset.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...string) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() string {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() string {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (string, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/strset/strset_test.go
+++ b/strset/strset_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 string
+	e := createRandomObject(e1)
+	if v, ok := e.(string); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(string); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 string
 	e := createRandomObject(e1)

--- a/u16set/u16set.go
+++ b/u16set/u16set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() uint16 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (uint16, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...uint16) bool {

--- a/u16set/u16set.go
+++ b/u16set/u16set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...uint16) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() uint16 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() uint16 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (uint16, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/u16set/u16set_test.go
+++ b/u16set/u16set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 uint16
+	e := createRandomObject(e1)
+	if v, ok := e.(uint16); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(uint16); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 uint16
 	e := createRandomObject(e1)

--- a/u32set/u32set.go
+++ b/u32set/u32set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() uint32 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (uint32, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...uint32) bool {

--- a/u32set/u32set.go
+++ b/u32set/u32set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...uint32) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() uint32 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() uint32 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (uint32, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/u32set/u32set_test.go
+++ b/u32set/u32set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 uint32
+	e := createRandomObject(e1)
+	if v, ok := e.(uint32); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(uint32); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 uint32
 	e := createRandomObject(e1)

--- a/u64set/u64set.go
+++ b/u64set/u64set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() uint64 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (uint64, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...uint64) bool {

--- a/u64set/u64set.go
+++ b/u64set/u64set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...uint64) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() uint64 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() uint64 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (uint64, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/u64set/u64set_test.go
+++ b/u64set/u64set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 uint64
+	e := createRandomObject(e1)
+	if v, ok := e.(uint64); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(uint64); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 uint64
 	e := createRandomObject(e1)

--- a/u8set/u8set.go
+++ b/u8set/u8set.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...uint8) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() uint8 {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() uint8 {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (uint8, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/u8set/u8set.go
+++ b/u8set/u8set.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() uint8 {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (uint8, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...uint8) bool {

--- a/u8set/u8set_test.go
+++ b/u8set/u8set_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 uint8
+	e := createRandomObject(e1)
+	if v, ok := e.(uint8); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(uint8); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 uint8
 	e := createRandomObject(e1)

--- a/uset/uset.go
+++ b/uset/uset.go
@@ -50,8 +50,8 @@ func (s *Set) Remove(items ...uint) {
 	}
 }
 
-// Pop  deletes and return an item from the Set. The underlying Set s is
-// modified. If Set is empty, nil is returned.
+// Pop deletes and returns an item from the Set. The underlying Set s is
+// modified. If Set is empty, the zero value is returned.
 func (s *Set) Pop() uint {
 	for item := range s.m {
 		delete(s.m, item)
@@ -61,8 +61,9 @@ func (s *Set) Pop() uint {
 }
 
 // Pop2 tries to delete and return an item from the Set. The underlying Set s
-// is modified. The boolean flag returned indicates if an item was found. If
-// Set is empty, the zero value is returned with the flag set as false.
+// is modified. The second value is a bool that is true if the item existed in
+// the set, and false if not. If Set is empty, the zero value and false are
+// returned.
 func (s *Set) Pop2() (uint, bool) {
 	for item := range s.m {
 		delete(s.m, item)

--- a/uset/uset.go
+++ b/uset/uset.go
@@ -60,6 +60,17 @@ func (s *Set) Pop() uint {
 	return nonExistent
 }
 
+// Pop2 tries to delete and return an item from the Set. The underlying Set s
+// is modified. The boolean flag returned indicates if an item was found. If
+// Set is empty, the zero value is returned with the flag set as false.
+func (s *Set) Pop2() (uint, bool) {
+	for item := range s.m {
+		delete(s.m, item)
+		return item, true
+	}
+	return nonExistent, false
+}
+
 // Has looks for the existence of items passed. It returns false if nothing is
 // passed. For multiple items it returns true only if all of  the items exist.
 func (s *Set) Has(items ...uint) bool {

--- a/uset/uset_test.go
+++ b/uset/uset_test.go
@@ -87,6 +87,39 @@ func TestPop(t *testing.T) {
 	}
 }
 
+func TestPop2(t *testing.T) {
+	var e1, e2 uint
+	e := createRandomObject(e1)
+	if v, ok := e.(uint); ok {
+		e1 = v
+	}
+	e = createRandomObject(e2)
+	if v, ok := e.(uint); ok {
+		e2 = v
+	}
+
+	s := New()
+	popped, found := s.Pop2()
+	if popped != nonExistent {
+		t.Errorf("default non existent sentinel not returned, instead got %v", popped)
+	}
+	if found {
+		t.Errorf("set is empty, no element should have been found")
+	}
+
+	s.Add(e1)
+	s.Add(e2)
+
+	_, found = s.Pop2()
+
+	if len(s.m) != 1 {
+		t.Errorf("expected 1 entries, got %d", len(s.m))
+	}
+	if !found {
+		t.Errorf("expected to find an entry")
+	}
+}
+
 func TestHas(t *testing.T) {
 	var e1, e2, e3 uint
 	e := createRandomObject(e1)


### PR DESCRIPTION
As discussed in issue #11, there is no way to find out if a zero value was returned
because it was part of the Set or because the Set was empty. This adds the Pop2 function
with an extra boolean return value to make the distinction.

Let me know if you want changes in the signature or the documentation. I'm not that happy with the docs for `Pop2` to be honest.

Closes #11.