### PR TITLE
Fix github issue #16 compile error on x86 arch

### DIFF
--- a/b16set/b16set.go
+++ b/b16set/b16set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent [16]byte
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b16set/b16set.go
+++ b/b16set/b16set.go
@@ -6,7 +6,6 @@ package b16set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent [16]byte
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b32set/b32set.go
+++ b/b32set/b32set.go
@@ -6,7 +6,6 @@ package b32set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent [32]byte
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b32set/b32set.go
+++ b/b32set/b32set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent [32]byte
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b64set/b64set.go
+++ b/b64set/b64set.go
@@ -6,7 +6,6 @@ package b64set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent [64]byte
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b64set/b64set.go
+++ b/b64set/b64set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent [64]byte
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b8set/b8set.go
+++ b/b8set/b8set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent [8]byte
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/b8set/b8set.go
+++ b/b8set/b8set.go
@@ -6,7 +6,6 @@ package b8set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent [8]byte
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/f32set/f32set.go
+++ b/f32set/f32set.go
@@ -6,7 +6,6 @@ package f32set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent float32
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/f32set/f32set.go
+++ b/f32set/f32set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent float32
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/f64set/f64set.go
+++ b/f64set/f64set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent float64
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/f64set/f64set.go
+++ b/f64set/f64set.go
@@ -6,7 +6,6 @@ package f64set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent float64
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i16set/i16set.go
+++ b/i16set/i16set.go
@@ -6,7 +6,6 @@ package i16set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent int16
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i16set/i16set.go
+++ b/i16set/i16set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent int16
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i32set/i32set.go
+++ b/i32set/i32set.go
@@ -6,7 +6,6 @@ package i32set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent int32
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i32set/i32set.go
+++ b/i32set/i32set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent int32
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i64set/i64set.go
+++ b/i64set/i64set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent int64
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i64set/i64set.go
+++ b/i64set/i64set.go
@@ -6,7 +6,6 @@ package i64set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent int64
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i8set/i8set.go
+++ b/i8set/i8set.go
@@ -6,7 +6,6 @@ package i8set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent int8
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/i8set/i8set.go
+++ b/i8set/i8set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent int8
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent T
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -6,7 +6,6 @@ package set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent T
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/iset/iset.go
+++ b/iset/iset.go
@@ -15,7 +15,7 @@ var (
 	nonExistent int
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/iset/iset.go
+++ b/iset/iset.go
@@ -6,7 +6,6 @@ package iset
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent int
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/strset/strset.go
+++ b/strset/strset.go
@@ -6,7 +6,6 @@ package strset
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent string
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/strset/strset.go
+++ b/strset/strset.go
@@ -15,7 +15,7 @@ var (
 	nonExistent string
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u16set/u16set.go
+++ b/u16set/u16set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent uint16
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u16set/u16set.go
+++ b/u16set/u16set.go
@@ -6,7 +6,6 @@ package u16set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent uint16
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u32set/u32set.go
+++ b/u32set/u32set.go
@@ -6,7 +6,6 @@ package u32set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent uint32
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u32set/u32set.go
+++ b/u32set/u32set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent uint32
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u64set/u64set.go
+++ b/u64set/u64set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent uint64
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u64set/u64set.go
+++ b/u64set/u64set.go
@@ -6,7 +6,6 @@ package u64set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent uint64
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u8set/u8set.go
+++ b/u8set/u8set.go
@@ -6,7 +6,6 @@ package u8set
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent uint8
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 

--- a/u8set/u8set.go
+++ b/u8set/u8set.go
@@ -15,7 +15,7 @@ var (
 	nonExistent uint8
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/uset/uset.go
+++ b/uset/uset.go
@@ -15,7 +15,7 @@ var (
 	nonExistent uint
 )
 
-const MaxInt = int(^uint(0) >> 1)
+const maxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -246,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := MaxInt
+	minSize := maxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == MaxInt || minSize == 0 {
+	if minSize == maxInt || minSize == 0 {
 		return New()
 	}
 

--- a/uset/uset.go
+++ b/uset/uset.go
@@ -6,7 +6,6 @@ package uset
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ var (
 	keyExists   = struct{}{}
 	nonExistent uint
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 // Set is the main set structure that holds all the data
 // and methods used to working with the set.
@@ -245,14 +246,14 @@ func Difference(set1 *Set, sets ...*Set) *Set {
 // given sets.
 func Intersection(sets ...*Set) *Set {
 	minPos := -1
-	minSize := math.MaxInt64
+	minSize := MaxInt
 	for i, set := range sets {
 		if l := set.Size(); l < minSize {
 			minSize = l
 			minPos = i
 		}
 	}
-	if minSize == math.MaxInt64 || minSize == 0 {
+	if minSize == MaxInt || minSize == 0 {
 		return New()
 	}
 


### PR DESCRIPTION
See issue #16:

Replaced `math.MaxInt64` with `int(^uint(0) >> 1)` which is architecture agnostic